### PR TITLE
cure fail

### DIFF
--- a/SGAI_MK3/Board.py
+++ b/SGAI_MK3/Board.py
@@ -345,7 +345,6 @@ class Board:
                         p.get_cured()
                     else:
                         print("Cure Failed")
-                        return [False, None]
                 else:
                     return [False, None]
             else:


### PR DESCRIPTION
was returning [False, None], and thus when the cure failed resources were spent but it didn't count as a move